### PR TITLE
feature/#12-user-manager-role

### DIFF
--- a/src/main/java/com/sparta/bitbucket/auth/dto/SignupRequestDto.java
+++ b/src/main/java/com/sparta/bitbucket/auth/dto/SignupRequestDto.java
@@ -30,10 +30,13 @@ public class SignupRequestDto {
 	@NotBlank(message = "Name cannot be blank.")
 	private String name;
 
+	private String secretKey;
+
 	@Builder
-	public SignupRequestDto(String email, String password, String name) {
+	public SignupRequestDto(String email, String password, String name, String secretKey) {
 		this.email = email;
 		this.password = password;
 		this.name = name;
+		this.secretKey = secretKey;
 	}
 }

--- a/src/main/java/com/sparta/bitbucket/auth/dto/SignupResponseDto.java
+++ b/src/main/java/com/sparta/bitbucket/auth/dto/SignupResponseDto.java
@@ -1,5 +1,8 @@
 package com.sparta.bitbucket.auth.dto;
 
+import java.time.LocalDateTime;
+
+import com.sparta.bitbucket.auth.entity.Role;
 import com.sparta.bitbucket.auth.entity.User;
 
 import lombok.Getter;
@@ -14,6 +17,8 @@ public class SignupResponseDto {
 
 	private String email;
 	private String name;
+	private Role role;
+	private LocalDateTime createdAt;
 
 	/**
 	 * User Entity 데이터로 초기화.
@@ -23,5 +28,7 @@ public class SignupResponseDto {
 	public SignupResponseDto(User user) {
 		this.email = user.getEmail();
 		this.name = user.getName();
+		this.role = user.getRole();
+		this.createdAt = user.getCreatedAt();
 	}
 }

--- a/src/main/java/com/sparta/bitbucket/auth/entity/Role.java
+++ b/src/main/java/com/sparta/bitbucket/auth/entity/Role.java
@@ -7,11 +7,11 @@ import lombok.Getter;
  * <p>
  * USER 일반 사용자 역할
  * <p>
- * ADMIN 관리자 역할
+ * MANAGER 관리자 역할
  */
 @Getter
 public enum Role {
-	USER("ROLE_USER"), MANAGER ("ROLE_MANAGER");
+	USER("ROLE_USER"), MANAGER("ROLE_MANAGER");
 
 	private final String role;
 

--- a/src/main/java/com/sparta/bitbucket/auth/entity/User.java
+++ b/src/main/java/com/sparta/bitbucket/auth/entity/User.java
@@ -56,7 +56,7 @@ public class User extends Timestamped {
 		this.email = email;
 		this.password = password;
 		this.name = name;
-		this.role = role != null ? role : Role.USER;
+		this.role = role;
 	}
 
 	/**

--- a/src/main/java/com/sparta/bitbucket/common/util/ResponseFactory.java
+++ b/src/main/java/com/sparta/bitbucket/common/util/ResponseFactory.java
@@ -14,10 +14,10 @@ import com.sparta.bitbucket.common.dto.NoContentResponseDto;
  */
 public class ResponseFactory {
 
-	private static final String MSG_OK = "The request has been successfully processed."; // todo : 영어? 한글?
-	private static final String MSG_BAD_REQUEST = "The request could not be understood or was missing required parameters.";
-	private static final String MSG_NOT_FOUND = "The requested resource could not be found.";
-	private static final String MSG_INTERNAL_SERVER_ERROR = "An unexpected condition was encountered.";
+	private static final String MSG_OK = "요청이 성공적으로 완료되었습니다.";
+	private static final String MSG_BAD_REQUEST = "해당 요청을 처리할 수 없습니다.";
+	private static final String MSG_NOT_FOUND = "요청한 리소스를 찾을 수 없습니다.";
+	private static final String MSG_INTERNAL_SERVER_ERROR = "서버 오류가 발생했습니다.";
 	private final static int STATUS_OK = HttpStatus.OK.value();
 	private final static int STATUS_NO_CONTENT = HttpStatus.NO_CONTENT.value();
 	private final static int STATUS_BAD_REQUEST = HttpStatus.BAD_REQUEST.value();


### PR DESCRIPTION
<br/>

## 🔎  제목 : feature/#12-user-manager-role 구현

<br/>

## 🔎 작업 내용

- secretKey 추가 및 비교

- ResponseFactory 기본 메세지 영어에서 한글로 변경

- SignupResponseDto에 role, createdAt 추가

<br/>

## 🔎  실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)
토큰 필요 없음

### Test1
{
    "email": "test56@example.com",
    "password": "Test1234!@",
    "name": "Lee",
    "secretKey": "{secret-key}"
}
![스크린샷 2024-07-10 225214](https://github.com/Bitbucket22/Bitbucket/assets/43354156/9635322d-8894-435f-ab35-32df2e6d0508)

### Test2

{
    "email": "test57@example.com",
    "password": "Test1234!@",
    "name": "Lee",
    "secretKey": ""
}
![스크린샷 2024-07-10 225307](https://github.com/Bitbucket22/Bitbucket/assets/43354156/55cc9262-84b2-4651-8ab1-51deb820534f)

### Test3

{
    "email": "test58@example.com",
    "password": "Test1234!@",
    "name": "Lee"
}
![스크린샷 2024-07-10 225314](https://github.com/Bitbucket22/Bitbucket/assets/43354156/31ed5291-d001-4451-8b64-9fac92ba4209)

실패는 전역 처리 기능 이후에 확인해서 추가해놓겠습니다.

테스트 키는 application-secret.properties에 추가해놓고 사용하시면 됩니다.
manager-secret-key = "{{개인적인 secret key 사용}}"

<br/>

## 🔎   앞으로의 과제

- GlobalExceptionHandler가 추가되면 실패 경우도 확인하기

- Frontend 작업

- 문제있는 기능 고치기

  <br/>
